### PR TITLE
Schedule view cleanup

### DIFF
--- a/app/src/components/App/Schedule/ScheduleRow/index.jsx
+++ b/app/src/components/App/Schedule/ScheduleRow/index.jsx
@@ -26,11 +26,15 @@ const ScheduleRow = ({ role, memberId, scheduleList, selectMember }) => {
         {
           scheduleRow &&
             <div>
-              {scheduleRow.lastRoleName || 'none'} on {scheduleRow.lastServedDate|| ''}
+              {scheduleRow.lastRoleName || 'none'} on {scheduleRow.lastServedDate || 'n/a'}
             </div>
         }
       </div>
       <div className={styles.memberDetail}>{scheduleRow ? scheduleRow.comment : ''}</div>
+      {/*
+        the server does not provide contact data yet,
+        see "[log] api.schedule.scheduleMembers: data " in the console
+         */}
       <div className={styles.memberDetail}> [contact] </div>
     </div>
   )

--- a/app/src/components/App/Schedule/index.jsx
+++ b/app/src/components/App/Schedule/index.jsx
@@ -28,13 +28,12 @@ class Schedule extends Component {
   }
 
   render() {
-    const { scheduleMembers, roles, exclusions, rolesForMembers } = this.props
+    const { scheduleMembers, roles, exclusions, upcomingSchedule } = this.props
     // ku.log('Schedule: scheduleMembers', scheduleMembers, 'blue')
     // ku.log('Schedule: roles', roles, 'blue')
     // ku.log('Schedule: exclusions', exclusions, 'blue')
-    ku.log('rolesForMembers', rolesForMembers, 'blue')
+    ku.log('upcomingSchedule', upcomingSchedule, 'blue')
     const scheduleList = scheduleMembers.map((m) => {
-      console.log('=======', m)
       const rMember = {
         memberId: m.member_id,
         sequence: m.sequence,
@@ -77,7 +76,7 @@ class Schedule extends Component {
       <ScheduleRow
         key={index}
         role={r}
-        memberId={rolesForMembers[r.role_id] || '1'}
+        memberId={upcomingSchedule[r.role_id] || '1'}
         scheduleList={scheduleList}
         selectMember={this.handleSelectMember}
       />
@@ -107,7 +106,7 @@ const mapStateToProps = (state) => {
     scheduleMembers: selectors.getScheduleMembers(state),
     roles: selectors.getRoles(state),
     exclusions: selectors.getExclusions(state),
-    rolesForMembers: selectors.getRolesForMembers(state)
+    upcomingSchedule: selectors.getUpcomingSchedule(state)
   }
   return o
 }

--- a/app/src/components/App/Schedule/index.jsx
+++ b/app/src/components/App/Schedule/index.jsx
@@ -34,6 +34,7 @@ class Schedule extends Component {
     // ku.log('Schedule: exclusions', exclusions, 'blue')
     ku.log('rolesForMembers', rolesForMembers, 'blue')
     const scheduleList = scheduleMembers.map((m) => {
+      console.log('=======', m)
       const rMember = {
         memberId: m.member_id,
         sequence: m.sequence,

--- a/app/src/store/reducers.js
+++ b/app/src/store/reducers.js
@@ -131,7 +131,7 @@ export const exclusionsIds = (state = [], { type, payload }) => {
   }
 }
 
-export const scheduleMembersRoles = (state = {}, { type, payload }) => {
+export const upcomingSchedule = (state = {}, { type, payload }) => {
   switch (type) {
     case 'app/setSchedule':
       return merge(state, payload)
@@ -152,7 +152,7 @@ export default combineReducers({
     rolesIds,
     exclusionsById,
     exclusionsIds,
-    scheduleMembersRoles,
+    upcomingSchedule,
   }),
   openMemberId,
   requests,

--- a/app/src/store/selectors.js
+++ b/app/src/store/selectors.js
@@ -13,8 +13,8 @@ export const getRoles = (state) => {
 export const getExclusions = (state) => {
   return state.schedule.exclusionsIds.map((id) => state.schedule.exclusionsById[id]);
 }
-export const getRolesForMembers = (state) => {
-  return state.schedule.scheduleMembersRoles
+export const getUpcomingSchedule = (state) => {
+  return state.schedule.upcomingSchedule
 }
 // redux selectors
 export const getRequest = (state, key) =>


### PR DESCRIPTION
### Changes
Some small changes, as discussed in today's zoom call
- add a comment about server not sending contact info
- rename selector and reducer to be more meaningful (changed to 'upcomingSchedule')